### PR TITLE
Various non-functional cleanups.

### DIFF
--- a/copycat/codeletMethods.py
+++ b/copycat/codeletMethods.py
@@ -115,7 +115,7 @@ def __fightIncompatibles(incompatibles, structure, name,
 
 def __slippability(conceptMappings):
     for mapping in conceptMappings:
-        slippiness = mapping.slipability() / 100.0
+        slippiness = mapping.slippability() / 100.0
         probabilityOfSlippage = formulas.temperatureAdjustedProbability(
             slippiness)
         if formulas.coinFlip(probabilityOfSlippage):

--- a/copycat/conceptMapping.py
+++ b/copycat/conceptMapping.py
@@ -24,7 +24,7 @@ class ConceptMapping(object):
     def __str__(self):
         return self.label and self.label.name or 'anonymous'
 
-    def slipability(self):
+    def slippability(self):
         association = self.__degreeOfAssociation()
         if association == 100.0:
             return 100.0

--- a/copycat/conceptMapping.py
+++ b/copycat/conceptMapping.py
@@ -79,6 +79,7 @@ class ConceptMapping(object):
     def sameDescriptors(self, other):
         if self.sameInitialDescriptor(other):
             return self.sameTargetDescriptor(other)
+        return False
 
     def sameKind(self, other):
         return self.sameTypes(other) and self.sameDescriptors(other)
@@ -87,10 +88,10 @@ class ConceptMapping(object):
         return self.sameTypes(other) and self.sameInitialDescriptor(other)
 
     def isContainedBy(self, mappings):
-        return any([self.sameKind(mapping) for mapping in mappings])
+        return any(self.sameKind(mapping) for mapping in mappings)
 
     def isNearlyContainedBy(self, mappings):
-        return any([self.nearlySameKind(mapping) for mapping in mappings])
+        return any(self.nearlySameKind(mapping) for mapping in mappings)
 
     def related(self, other):
         if self.initialDescriptor.related(other.initialDescriptor):
@@ -136,10 +137,12 @@ class ConceptMapping(object):
     def relevant(self):
         if self.initialDescriptionType.fully_active():
             return self.targetDescriptionType.fully_active()
+        return False
 
     def slippage(self):
         if self.label != slipnet.sameness:
             return self.label != slipnet.identity
+        return False
 
     def symmetricVersion(self):
         if not self.slippage():

--- a/copycat/rule.py
+++ b/copycat/rule.py
@@ -91,8 +91,8 @@ class Rule(WorkspaceStructure):
         if correspondence.objectFromInitial != changed:
             return False
         # it is incompatible if the rule descriptor is not in the mapping list
-        return bool([m for m in correspondence.conceptMappings
-                     if m.initialDescriptor == self.descriptor])
+        return any(m.initialDescriptor == self.descriptor
+                   for m in correspondence.conceptMappings)
 
     def __changeString(self, string):
         # applies the changes to self string ie. successor

--- a/copycat/slipnet.py
+++ b/copycat/slipnet.py
@@ -35,7 +35,8 @@ class SlipNet(object):
 
     def setConceptualDepths(self, depth):
         logging.debug('slipnet set all depths to %f', depth)
-        _ = [node.setConceptualDepth(depth) for node in self.slipnodes]
+        for node in self.slipnodes:
+            node.setConceptualDepth(depth)
 
     def reset(self):
         logging.debug('slipnet.reset()')
@@ -49,8 +50,10 @@ class SlipNet(object):
         logging.debug('slipnet.update()')
         self.numberOfUpdates += 1
         if self.numberOfUpdates == 50:
-            _ = [node.unclamp() for node in self.initiallyClampedSlipnodes]
-        _ = [node.update() for node in self.slipnodes]
+            for node in self.initiallyClampedSlipnodes:
+                node.unclamp()
+        for node in self.slipnodes:
+            node.update()
         for node in self.slipnodes:
             node.spread_activation()
         for node in self.slipnodes:

--- a/copycat/slipnode.py
+++ b/copycat/slipnode.py
@@ -13,7 +13,7 @@ def jump_threshold():
 
 def points_at(links, other):
     """Whether any of the links points at the other"""
-    return any([l.points_at(other) for l in links])
+    return any(l.points_at(other) for l in links)
 
 
 class Slipnode(object):
@@ -124,8 +124,7 @@ class Slipnode(object):
                         for l in self.outgoingLinks if l.label == relation]
         if destinations:
             return destinations[0]
-        node = None
-        return node
+        return None
 
     def getBondCategory(self, destination):
         """Return the label of the link between these nodes if it exists.
@@ -150,13 +149,13 @@ class Slipnode(object):
 
     def spread_activation(self):
         if self.fully_active():
-            _ = [link.spread_activation() for link in self.outgoingLinks]
+            for link in self.outgoingLinks:
+                link.spread_activation()
 
     def addBuffer(self):
         if self.unclamped():
             self.activation += self.buffer
-        self.activation = min(self.activation, 100)
-        self.activation = max(self.activation, 0)
+        self.activation = min(max(0, self.activation), 100)
 
     def can_jump(self):
         if self.activation <= jump_threshold():

--- a/copycat/workspaceObject.py
+++ b/copycat/workspaceObject.py
@@ -161,7 +161,7 @@ class WorkspaceObject(WorkspaceStructure):
         return False
 
     def described(self, slipnode):
-        return bool([d for d in self.descriptions if d.descriptor == slipnode])
+        return any(d.descriptor == slipnode for d in self.descriptions)
 
     def middleObject(self):
         # only works if string is 3 chars long


### PR DESCRIPTION
I really want to change a lot of these `if x: return y; return False` to simply `return x and y`; but doing so in the natural way would make the lines longer than 80 columns, and all the possible ways of breaking those lines look horrible, so I'm just leaving them as-is.
Returning `False` instead of `None` in those cases strikes me as a good idea for type-safety-sanity, regardless.