### PR TITLE
Run multiple iterations. Print final temperatures. Reduce stdout spew.

### DIFF
--- a/copycat/codeletMethods.py
+++ b/copycat/codeletMethods.py
@@ -31,7 +31,7 @@ def __showWhichStringObjectIsFrom(structure):
         whence = 'target'
         if structure.string == workspace.initial:
             whence = 'initial'
-    print 'object chosen = %s from %s string' % (structure, whence)
+    #print 'object chosen = %s from %s string' % (structure, whence)
 
 
 def __getScoutSource(slipnode, relevanceMethod, typeName):

--- a/copycat/copycat.py
+++ b/copycat/copycat.py
@@ -1,7 +1,4 @@
 import logging
-logging.basicConfig(level=logging.INFO, format='%(message)s',
-                    filename='./copycat.log', filemode='w')
-
 
 from workspace import workspace
 from workspaceFormulas import workspaceFormulas
@@ -33,9 +30,8 @@ def mainLoop(lastUpdate):
     return result
 
 
-def runTrial():
+def runTrial(answers):
     """Run a trial of the copycat algorithm"""
-    answers = {}
     slipnet.reset()
     workspace.reset()
     coderack.reset()
@@ -46,13 +42,20 @@ def runTrial():
         answer = workspace.rule.finalAnswer
     else:
         answer = None
-    print '%d: %s' % (coderack.codeletsRun, answer)
-    answers[answer] = answers.get(answer, 0) + 1
-    logging.debug('codelets used:')
-    for answer, count in answers.iteritems():
-        print '%s:%d' % (answer, count)
+    finalTemperature = temperature.value
+    print 'Answered %s (time %d, final temperature %.1f)' % (answer, coderack.codeletsRun, finalTemperature)
+    answers[answer] = answers.get(answer, {'count': 0, 'tempsum': 0})
+    answers[answer]['count'] += 1
+    answers[answer]['tempsum'] += finalTemperature
 
 
-def run(initial, modified, target):
+def run(initial, modified, target, iterations):
     workspace.setStrings(initial, modified, target)
-    runTrial()
+    answers = {}
+    for i in xrange(iterations):
+        runTrial(answers)
+    for answer, d in answers.iteritems():
+        d['avgtemp'] = d['tempsum'] / d['count']
+        d.pop('tempsum')
+    for answer, d in sorted(answers.iteritems(), key=lambda kv: kv[1]['avgtemp']):
+        print '%s: %d (avg temp %.1f)' % (answer, d['count'], d['avgtemp'])

--- a/copycat/copycat.py
+++ b/copycat/copycat.py
@@ -43,10 +43,12 @@ def runTrial(answers):
     else:
         answer = None
     finalTemperature = temperature.value
-    print 'Answered %s (time %d, final temperature %.1f)' % (answer, coderack.codeletsRun, finalTemperature)
-    answers[answer] = answers.get(answer, {'count': 0, 'tempsum': 0})
+    finalTime = coderack.codeletsRun
+    print 'Answered %s (time %d, final temperature %.1f)' % (answer, finalTime, finalTemperature)
+    answers[answer] = answers.get(answer, {'count': 0, 'tempsum': 0, 'timesum': 0})
     answers[answer]['count'] += 1
     answers[answer]['tempsum'] += finalTemperature
+    answers[answer]['timesum'] += finalTime
 
 
 def run(initial, modified, target, iterations):
@@ -55,7 +57,6 @@ def run(initial, modified, target, iterations):
     for i in xrange(iterations):
         runTrial(answers)
     for answer, d in answers.iteritems():
-        d['avgtemp'] = d['tempsum'] / d['count']
-        d.pop('tempsum')
-    for answer, d in sorted(answers.iteritems(), key=lambda kv: kv[1]['avgtemp']):
-        print '%s: %d (avg temp %.1f)' % (answer, d['count'], d['avgtemp'])
+        d['avgtemp'] = d.pop('tempsum') / d['count']
+        d['avgtime'] = d.pop('timesum') / d['count']
+    return answers

--- a/copycat/main.py
+++ b/copycat/main.py
@@ -1,6 +1,6 @@
 """Run the copycat program"""
 
-
+import logging
 import sys
 
 import copycat
@@ -8,12 +8,20 @@ import copycat
 
 def main(program, args):
     """Run the program"""
+    logging.basicConfig(level=logging.WARN, format='%(message)s',
+                        filename='./copycat.log', filemode='w')
+
     try:
-        initial, modified, target = args
-        copycat.run(initial, modified, target)
+        if len(args) == 4:
+            initial, modified, target = args[:-1]
+            iterations = int(args[-1])
+        else:
+            initial, modified, target = args
+            iterations = 1
+        copycat.run(initial, modified, target, iterations)
         return 0
     except ValueError:
-        print >> sys.stderr, 'Usage: %s initial modified target' % program
+        print >> sys.stderr, 'Usage: %s initial modified target [iterations]' % program
         return 1
 
 

--- a/copycat/main.py
+++ b/copycat/main.py
@@ -18,7 +18,9 @@ def main(program, args):
         else:
             initial, modified, target = args
             iterations = 1
-        copycat.run(initial, modified, target, iterations)
+        answers = copycat.run(initial, modified, target, iterations)
+        for answer, d in sorted(answers.iteritems(), key=lambda kv: kv[1]['avgtemp']):
+            print '%s: %d (avg time %.1f, avg temp %.1f)' % (answer, d['count'], d['avgtime'], d['avgtemp'])
         return 0
     except ValueError:
         print >> sys.stderr, 'Usage: %s initial modified target [iterations]' % program


### PR DESCRIPTION
This makes the output of the program more closely resemble that of the
original Copycat described in "FCCA" page 236:

> [T]he average final temperature of an answer can be thought of as
> the program's own assessment of that answer's quality, with lower
> temperatures meaning higher quality.

For example, running `python main.py abc abd ijk 100` produced the
following output:

    ijl: 98 (avg temp 16.0)
    jjk: 1 (avg temp 56.3)
    ijk: 1 (avg temp 57.9)

And for `python main.py abc abd ijkk 100`:

    ijkkk: 2 (avg temp 19.8)
    ijkl: 51 (avg temp 28.1)
    ijll: 46 (avg temp 28.9)
    djkk: 1 (avg temp 77.4)