### PR TITLE
Prefer the newer inspect.signature()

### DIFF
--- a/copycat/coderack.py
+++ b/copycat/coderack.py
@@ -369,7 +369,7 @@ class CodeRack:
             )
         if not callable(method):
             raise RuntimeError(f"Cannot call {method_name}()")
-        args, _varargs, _varkw, _defaults = inspect.getargspec(method)
+        args = inspect.signature(method).parameters
         try:
             if "codelet" in args:
                 method(codelet)


### PR DESCRIPTION
over deprecated inspect.getargspec()

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request updates the code to use inspect.signature() instead of the deprecated inspect.getargspec() method, ensuring better compatibility with future Python versions.

- **Enhancements**:
    - Replaced deprecated inspect.getargspec() with inspect.signature() for improved compatibility and future-proofing.

<!-- Generated by sourcery-ai[bot]: end summary -->